### PR TITLE
Corrected errors in Windows implementation of Terminal

### DIFF
--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -529,6 +529,7 @@ namespace Cedar::Terminal
             inputMode &= ~cookedModeInputFlags;
 
         (void)SetConsoleMode(g_internalData.stdInputHandle, inputMode);
+        g_internalData.mode = mode;
     }
 
 
@@ -542,7 +543,7 @@ namespace Cedar::Terminal
         if (enable)
             write("\033[?1049h");
         else
-            write("\033[?1049hl");
+            write("\033[?1049l");
 
         g_internalData.altScreenBufferEnabled = enable;
     }


### PR DESCRIPTION
- Fixed an error in the Windows version of Terminal::enableAltScreenBuffer that caused the incorrect screen buffer to be applied and an l to be printed to the console.
- Fixed an error in the Windows version of Terminal::setMode that prevented the terminal's current mode from updating.