### PR TITLE
Fixed Windows wide string to string conversion

### DIFF
--- a/src/platform/windows/windows_common.cpp
+++ b/src/platform/windows/windows_common.cpp
@@ -92,7 +92,7 @@ namespace Cedar::Platform::Windows
     {
         bool result = convertWideStringToString(wstr, str);
 
-        if (result)
+        if (!result)
             Cedar::Log::error("Failed to convert wide string to string");
 
         return result;


### PR DESCRIPTION
Fixed an error in Cedar::Platform::Windows::tryWideStringToString that caused it to incorrectly log an error when the conversion succeeded.