### PR TITLE
Simplified usage of IO features

### DIFF
--- a/Cedar.vcxproj
+++ b/Cedar.vcxproj
@@ -22,6 +22,7 @@
     <ClInclude Include="src\callback.h" />
     <ClInclude Include="src\core.h" />
     <ClInclude Include="src\input.h" />
+    <ClInclude Include="src\io.h" />
     <ClInclude Include="src\io\log.h" />
     <ClInclude Include="src\io\terminal.h" />
     <ClInclude Include="src\main\common_main.h" />

--- a/Cedar.vcxproj.filters
+++ b/Cedar.vcxproj.filters
@@ -57,6 +57,9 @@
     <ClInclude Include="src\callback.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\io.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\main\common_main.cpp">

--- a/src/io.h
+++ b/src/io.h
@@ -1,0 +1,11 @@
+//
+// A collection of header files located in the "io" directory.
+//
+
+#ifndef CEDAR_IO_H
+#define CEDAR_IO_H
+
+#include "io/log.h"
+#include "io/terminal.h"
+
+#endif // CEDAR_IO_H

--- a/src/io/terminal.cpp
+++ b/src/io/terminal.cpp
@@ -1,7 +1,6 @@
 #include "terminal.h"
 
 #include "../core.h"
-#include "../math.h"
 
 #include <cstddef>
 #include <new>

--- a/src/io/terminal.cpp
+++ b/src/io/terminal.cpp
@@ -26,21 +26,38 @@ namespace
 
 namespace
 {
+    constexpr DWORD vtProcessingOutputModeFlags = ENABLE_PROCESSED_OUTPUT |
+                                                  ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+
+
+
     struct TerminalData
     {
-        HANDLE inputHandle  = NULL;
-        HANDLE outputHandle = NULL;
-
+    public:
         
-        inline TerminalData() {}
+        inline TerminalData();
 
         inline ~TerminalData();
+
+    private:
+
+        DWORD m_originalOutputMode = 0;
     };
 
 
 
+    inline TerminalData::TerminalData()
+    {
+        (void)AttachConsole(ATTACH_PARENT_PROCESS);
+        (void)GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &m_originalOutputMode);
+        (void)SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), m_originalOutputMode | vtProcessingOutputModeFlags);
+    }
+
+
+
     inline TerminalData::~TerminalData() {
-        Cedar::Terminal::enable(false);
+        (void)SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), m_originalOutputMode);
+        (void)FreeConsole();
     }
 }
 
@@ -145,9 +162,6 @@ namespace Cedar::Terminal
 {
     void write(std::string_view str, Color foregroundColor, Color backgroundColor)
     {
-        if (!enabled())
-            return;
-
         setColors(foregroundColor, backgroundColor);
         writeInternal(str);
         resetColors();
@@ -155,9 +169,6 @@ namespace Cedar::Terminal
 
     void write(char character, Color foregroundColor, Color backgroundColor)
     {
-        if (!enabled())
-            return;
-
         setColors(foregroundColor, backgroundColor);
         writeInternal(character);
         resetColors();
@@ -176,59 +187,14 @@ namespace Cedar::Terminal
 
 namespace
 {
-    // Necessary for controlling the terminal through ANSI escape sequences
-    constexpr DWORD vtProcessingOutputModeFlags = ENABLE_PROCESSED_OUTPUT |
-                                                  ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-
-
-
     void writeInternal(std::string_view str)
     {
-        (void)WriteConsoleA(g_terminalData.outputHandle, str.data(), str.length(), NULL, NULL);
+        (void)WriteConsoleA(GetStdHandle(STD_OUTPUT_HANDLE), str.data(), str.length(), NULL, NULL);
     }
 
     void writeInternal(char character)
     {
-        (void)WriteConsoleA(g_terminalData.outputHandle, &character, 1, NULL, NULL);
-    }
-}
-
-
-
-namespace Cedar::Terminal
-{
-    void enable(bool enableTerminal)
-    {
-        if (enableTerminal == enabled())
-            return;
-
-        if (enableTerminal)
-        {
-            // TODO: Check result of AllocConsole.
-            (void)AllocConsole();
-            g_terminalData.inputHandle = GetStdHandle(STD_INPUT_HANDLE);
-            g_terminalData.outputHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-
-            // Make sure VT processing is enabled
-            DWORD outputMode;
-            (void)GetConsoleMode(g_terminalData.outputHandle, &outputMode);
-            outputMode |= vtProcessingOutputModeFlags;
-            (void)SetConsoleMode(g_terminalData.outputHandle, outputMode);
-        }
-        else
-        {
-            // TODO: Free result of AllocConsole.
-            (void)FreeConsole();
-            g_terminalData.inputHandle = NULL;
-            g_terminalData.outputHandle = NULL;
-        }
-    }
-
-
-
-    bool enabled()
-    {
-        return g_terminalData.outputHandle != NULL;
+        (void)WriteConsoleA(GetStdHandle(STD_OUTPUT_HANDLE), &character, 1, NULL, NULL);
     }
 }
 
@@ -249,26 +215,6 @@ namespace
     void writeInternal(char character)
     {
         (void)::write(STDOUT_FILENO, &character, 1);
-    }
-}
-
-
-
-namespace Cedar::Terminal
-{
-    void enable(bool enableTerminal)
-    {
-        // NOTE: This function and enabled() only exist because of how Windows' console
-        //       vs window subsystem works. These functions aren't necessary for Linux.
-    }
-
-
-
-    bool enabled()
-    {
-        // NOTE: This function and enable() only exist because of how Windows' console vs
-        //       window subsystem works. These functions aren't necessary for Linux.
-        return true;
     }
 }
 

--- a/src/io/terminal.cpp
+++ b/src/io/terminal.cpp
@@ -240,6 +240,66 @@ namespace Cedar::Terminal
 
 
 
+namespace
+{
+    enum class ColorType : int {
+        Foreground = 0,
+        Background = 10
+    };
+
+
+
+    void writeInternal(std::string_view str);
+
+    void writeInternal(char character);
+
+
+    void setColor(Cedar::Terminal::Color color, ColorType type);
+
+    void setColors(Cedar::Terminal::Color foregroundColor, Cedar::Terminal::Color backgroundColor);
+
+    void resetColors();
+
+
+
+    void writeInternal(std::string_view str)
+    {
+        (void)::write(STDOUT_FILENO, str.data(), str.length());
+    }
+
+
+
+    void writeInternal(char character)
+    {
+        (void)::write(STDOUT_FILENO, &character, 1);
+    }
+
+
+
+    void setColor(Cedar::Terminal::Color color, ColorType type)
+    {
+        if (color != Cedar::Terminal::Color::Use_Default)
+            writeInternal("\033[" + std::to_string(((int)color) + ((int)type)) + 'm');
+    }
+
+
+
+    void setColors(Cedar::Terminal::Color foregroundColor, Cedar::Terminal::Color backgroundColor)
+    {
+        setColor(foregroundColor, ColorType::Foreground);
+        setColor(backgroundColor, ColorType::Background);
+    }
+
+
+
+    void resetColors()
+    {
+        writeInternal("\033[0m");
+    }
+}
+
+
+
 namespace Cedar::Terminal
 {
     void enable(bool enableTerminal)
@@ -259,14 +319,20 @@ namespace Cedar::Terminal
 
 
 
-    void write(std::string_view str)
+    void write(std::string_view str, Color foregroundColor, Color backgroundColor)
     {
-        (void)::write(STDOUT_FILENO, str.data(), str.length());
+        setColors(foregroundColor, backgroundColor);
+        writeInternal(str);
+        resetColors();
     }
 
-    void write(char character)
+
+
+    void write(char character, Color foregroundColor, Color backgroundColor)
     {
-        (void)::write(STDOUT_FILENO, &character, 1);
+        setColors(foregroundColor, backgroundColor);
+        writeInternal(character);
+        resetColors();
     }
 }
 

--- a/src/io/terminal.h
+++ b/src/io/terminal.h
@@ -62,35 +62,16 @@ namespace Cedar::Terminal
     bool enabled();
 
 
+    void write(std::string_view str, Color foregroundColor = Color::Use_Default, Color backgroundColor = Color::Use_Default);
 
-    void write(std::string_view str);
-
-    void write(char character);
-
-    void write(std::string_view str, Color foregroundColor, Color backgroundColor);
-
-    void write(char character, Color foregroundColor, Color backgroundColor);
+    void write(char character, Color foregroundColor = Color::Use_Default, Color backgroundColor = Color::Use_Default);
 
 
-    inline void writeLine(std::string_view str);
+    inline void writeLine(std::string_view str, Color foregroundColor = Color::Use_Default, Color backgroundColor = Color::Use_Default);
 
-    inline void writeLine(char character);
-
-    inline void writeLine(std::string_view str, Color foregroundColor, Color backgroundColor);
-
-    inline void writeLine(char character, Color foregroundColor, Color backgroundColor);
+    inline void writeLine(char character, Color foregroundColor = Color::Use_Default, Color backgroundColor = Color::Use_Default);
 
 
-
-    inline void writeLine(std::string_view str) {
-        write(str);
-        write('\n');
-    }
-
-    inline void writeLine(char character) {
-        write(character);
-        write('\n');
-    }
 
     inline void writeLine(std::string_view str, Color foregroundColor, Color backgroundColor) {
         write(str, foregroundColor, backgroundColor);

--- a/src/io/terminal.h
+++ b/src/io/terminal.h
@@ -54,12 +54,6 @@ namespace Cedar::Terminal
     };
 
 
-
-    void enable(bool enableTerminal);
-
-    bool enabled();
-
-
     void write(std::string_view str, Color foregroundColor = Color::Use_Default, Color backgroundColor = Color::Use_Default);
 
     void write(char character, Color foregroundColor = Color::Use_Default, Color backgroundColor = Color::Use_Default);

--- a/src/io/terminal.h
+++ b/src/io/terminal.h
@@ -5,8 +5,6 @@
 #ifndef CEDAR_IO_TERMINAL_H
 #define CEDAR_IO_TERMINAL_H
 
-#include "../math.h"
-
 #include <cstddef>
 #include <string_view>
 

--- a/src/main/common_main.cpp
+++ b/src/main/common_main.cpp
@@ -46,7 +46,6 @@ int commonMain(int argc, char* argv[])
 
     try
     {
-        Cedar::Terminal::enable(true);
         Cedar::Log::setMinLevel(Cedar::Log::Level::Trace);
 
         CEDAR_LOG_TRACE("Entered commonMain");


### PR DESCRIPTION
- Added io.h to simplify the inclusion of headers in the io directory.
- Simplified Cedar::Terminal's write and writeLine overloads by adding default color parameters and removing the redundant versions that did not have color parameters.
- Removed Cedar::Terminal::enable and Cedar::Terminal::enabled. This reintroduces the ability for user input to be entered in a terminal while the engine is using the terminal, but it brings the expected behavior more in line with the Linux implementation.